### PR TITLE
Minor fixes

### DIFF
--- a/src/main/java/com/bigdata/json/query/service/PlanService.java
+++ b/src/main/java/com/bigdata/json/query/service/PlanService.java
@@ -1,53 +1,53 @@
 package com.bigdata.json.query.service;
 
+import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import java.util.Map;
 
 @Service
 public class PlanService {
 
     private final RedisTemplate<String, String> redisTemplate;
+    private final HashOperations<String, String, String> hashOperations;
 
     public PlanService(RedisTemplate<String, String> redisTemplate) {
         this.redisTemplate = redisTemplate;
+        this.hashOperations = redisTemplate.opsForHash();
     }
 
     private String dataKey(String objectId) {
         return "plan:data:" + objectId;
     }
 
-    private String etagKey(String objectId) {
-        return "plan:etag:" + objectId;
-    }
-
     /**
-     * Saves the JSON string and associated ETag to Redis.
+     * Saves the JSON string and associated ETag to Redis in a single hash
      */
     public void savePlan(String objectId, String json, String etag) {
-        // We could store them in a Redis hash, but for simplicity store them in separate keys
-        redisTemplate.opsForValue().set(dataKey(objectId), json);
-        redisTemplate.opsForValue().set(etagKey(objectId), etag);
+        hashOperations.putAll(dataKey(objectId), Map.of(
+                "json", json,
+                "etag", etag
+        ));
     }
 
     /**
      * Retrieves the JSON string by objectId, or null if not found.
      */
     public String getPlan(String objectId) {
-        return redisTemplate.opsForValue().get(dataKey(objectId));
+        return hashOperations.get(dataKey(objectId), "json");
     }
 
     /**
      * Retrieves the ETag for the stored JSON, or null if not found.
      */
     public String getEtag(String objectId) {
-        return redisTemplate.opsForValue().get(etagKey(objectId));
+        return hashOperations.get(dataKey(objectId), "etag");
     }
 
     /**
-     * Deletes the JSON and its ETag from Redis.
+     * Deletes the entire hash for the given objectId from Redis.
      */
     public void deletePlan(String objectId) {
         redisTemplate.delete(dataKey(objectId));
-        redisTemplate.delete(etagKey(objectId));
     }
 }

--- a/src/main/resources/schemas/plan-schema.json
+++ b/src/main/resources/schemas/plan-schema.json
@@ -58,7 +58,10 @@
     "objectId":   { "type": "string" },
     "objectType": { "type": "string" },
     "planType":   { "type": "string" },
-    "creationDate": { "type": "string" }
+    "creationDate": {
+      "type": "string",
+      "pattern": "^(\\d{4}-(0[13578]|1[02])-31|\\d{4}-(0[13-9]|1[0-2])-(0[1-9]|[12]\\d|30)|\\d{4}-02-(0[1-9]|1\\d|2[0-9])|(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01])-\\d{4}|(0[1-9]|[12]\\d|3[01])-(0[1-9]|1[0-2])-\\d{4})$"
+    }
   },
   "required": ["planCostShares", "linkedPlanServices", "objectId", "objectType", "planType"]
 }


### PR DESCRIPTION
This PR introduces the following fixes:
1. Invalid date time format will not be accepted in the POST request payload
2. The etag and json string was previously getting stored as two different redis keys. Updated it to use a single key that maps to etag and json.